### PR TITLE
Schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,14 @@ directly at a FASTA. For workflows where several foreground groups use the same
 gene FASTA, `samples.csv` can instead point to a reusable `sequence` name and a
 separate `sequences.csv` can map each sequence name to its FASTA.
 
+To switch between modes, use the `shared_sequence_mode` setting in `config/config.yaml`
+
+If set to false (the default) only `samples.csv` is required, and AOC run the
+alignment steps once for each sample.
+
+If set to true, both `samples.csv` and `sequences.csv` are required, and AOC will run
+the alignment steps once for each unique sequence.
+
 ### Simple sample sheet
 
 ```

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -7,8 +7,24 @@
 
 # Core inputs / outputs
 samples_csv: samples.csv
-sequences_csv: sequences.csv
+# sequences_csv: sequences.csv
 outdir: results
+
+# Core settings:
+# `shared_sequence_mode`
+# If false, samples_csv must contain sample,codon_fasta,sequence_labels_csv
+# and the workflow will run one alignment per sample.
+# If true, samples_csv must contain sample,sequence,sequence_labels_csv and
+# sequences_csv must be provided and contain sequence,codon_fasta.
+# The workflow will then run one alignment per sequence.
+shared_sequence_mode: false
+# `preserve_test_sequences` keeps labeled Test sequences during duplicate
+# removal and TN93 clustering, even if this causes the retained alignment to
+# have duplicate sequences or exceed `tn93_max_seqs`.
+preserve_test_sequences: false
+# Branch-label behavior
+# If true, samples that include a labels CSV must produce at least one Test sequence.
+require_test_sequences: false
 
 # External executables
 # Leave these as-is if the tools are available on PATH in the AOC environment.
@@ -38,15 +54,10 @@ macse_runner: scripts/run_macse_with_heap.sh
 # exceed `tn93_max_seqs`.
 tn93_threshold: 0.01
 tn93_max_seqs: 20
-preserve_test_sequences: false
 
 # GARD MPI settings
 # `gard_processors` controls the number of MPI ranks used by mpirun for GARD.
 gard_processors: 4
-
-# Branch-label behavior
-# If true, samples that include a labels CSV must produce at least one Test sequence.
-require_test_sequences: false
 
 # MACSE Java memory tuning
 # Default behavior:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -20,6 +20,7 @@ import importlib.util
 import sys
 from pathlib import Path
 from snakemake.utils import validate
+from snakemake.exceptions import WorkflowError
 
 def _find_project_root():
     starts = [Path(__file__).resolve().parent, Path.cwd().resolve()]
@@ -151,9 +152,15 @@ if "sequence_labels_csv" not in samples_df.columns:
 samples_df["sample"] = samples_df["sample"].astype(str)
 
 if SHARED_SEQUENCE_MODE:
-    validate(samples_df, "schemas/per_sequence_samples.schema.yaml")
+    try:
+        validate(samples_df, "schemas/per_sequence_samples.schema.yaml")
+    except WorkflowError as e:
+        raise WorkflowError(f"Error validating samples.csv against schema:", e)
 else:
-    validate(samples_df, "schemas/per_sample_samples.schema.yaml")
+    try:
+        validate(samples_df, "schemas/per_sample_samples.schema.yaml")
+    except WorkflowError as e:
+        raise WorkflowError(f"Error validating samples.csv against schema:", e)
 
 if "sequence" in samples_df.columns:
     samples_df["sequence"] = samples_df["sequence"].astype(str)
@@ -174,7 +181,11 @@ else:
             f"paired with sequences_csv={SEQUENCES_CSV!r}"
         )
     sequence_fasta_df = pd.read_csv(SEQUENCES_CSV).copy()
-    validate(sequence_fasta_df, "schemas/sequences.schema.yaml")
+
+    try:
+        validate(sequence_fasta_df, "schemas/sequences.schema.yaml")
+    except WorkflowError as e:
+        raise WorkflowError(f"Error validating sequences.csv against schema:", e)
 
     required_sequences = {"sequence", "codon_fasta"}
     missing_sequences = required_sequences.difference(sequence_fasta_df.columns)
@@ -650,7 +661,10 @@ rule build_header_map_and_test_list:
         if sample_col is not None:
             df = df[df[sample_col].astype(str).str.strip() == str(wildcards.sample)].copy()
 
-        validate(df, params.schema)
+        try:
+            validate(df, params.schema)
+        except WorkflowError as e:
+            raise WorkflowError(f"[build_header_map_and_test_list] Error validating labels CSV against schema:", e)
 
         # heuristic column detection
         label_candidates  = ["label", "group", "set", "class", "foreground", "branchset"]

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -56,6 +56,7 @@ validate(config, "schemas/config.schema.yaml")
 
 BASEDIR = os.getcwd()
 OUTROOT = Path(config.get("outdir", "results"))
+SHARED_SEQUENCE_MODE = config["shared_sequence_mode"]
 SAMPLES_CSV = config.get("samples_csv", "samples.csv")
 SEQUENCES_CSV = config.get("sequences_csv", "sequences.csv")
 
@@ -149,6 +150,11 @@ if "sequence_labels_csv" not in samples_df.columns:
 
 samples_df["sample"] = samples_df["sample"].astype(str)
 
+if SHARED_SEQUENCE_MODE:
+    validate(samples_df, "schemas/per_sequence_samples.schema.yaml")
+else:
+    validate(samples_df, "schemas/per_sample_samples.schema.yaml")
+
 if "sequence" in samples_df.columns:
     samples_df["sequence"] = samples_df["sequence"].astype(str)
 else:
@@ -168,6 +174,8 @@ else:
             f"paired with sequences_csv={SEQUENCES_CSV!r}"
         )
     sequence_fasta_df = pd.read_csv(SEQUENCES_CSV).copy()
+    validate(sequence_fasta_df, "schemas/sequences.schema.yaml")
+
     required_sequences = {"sequence", "codon_fasta"}
     missing_sequences = required_sequences.difference(sequence_fasta_df.columns)
     if missing_sequences:
@@ -598,6 +606,8 @@ rule build_header_map_and_test_list:
         test_txt=os.path.join(str(OUTROOT), "{sample}", "{sample}.test_sequences.txt"),
     log:
         os.path.join(LOGDIR, "build_header_map_and_test_list.{sample}.log")
+    params:
+        schema="schemas/sequence_labels.schema.yaml"
     run:
         import os, re
         import pandas as pd
@@ -639,6 +649,8 @@ rule build_header_map_and_test_list:
         sample_col = "sample" if "sample" in df.columns else None
         if sample_col is not None:
             df = df[df[sample_col].astype(str).str.strip() == str(wildcards.sample)].copy()
+
+        validate(df, params.schema)
 
         # heuristic column detection
         label_candidates  = ["label", "group", "set", "class", "foreground", "branchset"]

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -19,6 +19,7 @@ import glob
 import importlib.util
 import sys
 from pathlib import Path
+from snakemake.utils import validate
 
 def _find_project_root():
     starts = [Path(__file__).resolve().parent, Path.cwd().resolve()]
@@ -51,6 +52,7 @@ alt.data_transformers.disable_max_rows()
 ###############################################################################
 
 configfile: "config/config.yaml"
+validate(config, "schemas/config.schema.yaml")
 
 BASEDIR = os.getcwd()
 OUTROOT = Path(config.get("outdir", "results"))

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -1,0 +1,161 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+description: Configuration schema for the AOC workflow
+properties:
+  # Core settings
+  shared_sequence_mode:
+    type: boolean
+    description: Whether to use shared-sequence mode (true) or per-sample mode (false)
+    default: false
+  preserve_test_sequences:
+    type: boolean
+    description: Keep labeled Test sequences during duplicate removal and clustering
+    default: false
+  require_test_sequences:
+    type: boolean
+    description: If labels CSV is provided, require at least one Test sequence
+    default: false
+  # Core inputs / outputs
+  samples_csv:
+    type: string
+    description: Path to the sample sheet, mandatory
+    default: samples.csv
+  sequences_csv:
+    type: string
+    description: Path to sequences sheet, mandatory if shared_sequence_mode is true
+  outdir:
+    type: string
+    description: Output directory for workflow results
+    default: results
+  # External executables
+  hyphy:
+    type: string
+    description: HyPhy executable name or path
+    default: hyphy
+  hyphy_mpi:
+    type: string
+    description: HyPhy MPI executable name or path
+    default: HYPHYMPI
+  mpirun:
+    type: string
+    description: MPI launcher executable name or path
+    default: mpirun
+  fasttree:
+    type: string
+    description: FastTree executable name or path
+    default: FastTree
+  macse_launcher:
+    type: string
+    description: MACSE launcher executable name or path
+    default: macse
+  # Helper scripts / bundled resources
+  remove_dups_bf:
+    type: string
+    description: Path to the HyPhy duplicate-removal batch file
+    default: software/remove-duplicates/remove-duplicates.bf
+  strike_ambigs_bf:
+    type: string
+    description: Path to the ambig-stripping HyPhy batch file
+    default: scripts/strike-ambigs.bf
+  label_tree_bf:
+    type: string
+    description: Path to the tree-labeling HyPhy batch file
+    default: software/LabelTrees/label-tree.bf
+  make_test_list_py:
+    type: string
+    description: Path to the sequence-header mapping helper script
+    default: scripts/make_sequence_header_map.py
+  tn93_cluster_py:
+    type: string
+    description: Path to the TN93 clustering helper script
+    default: scripts/tn93_cluster.py
+  merge_fel_py:
+    type: string
+    description: Path to the FEL merge helper script
+    default: scripts/MergeFELResults.py
+  merge_meme_py:
+    type: string
+    description: Path to the MEME merge helper script
+    default: scripts/MergeMEMEResults.py
+  exec_summary_py:
+    type: string
+    description: Path to the executive summary helper script
+    default: scripts/ExecutiveSummary.py
+  macse_runner:
+    type: string
+    description: Path to the MACSE wrapper script
+    default: scripts/run_macse_with_heap.sh
+  # TN93 clustering
+  tn93_threshold:
+    type: number
+    description: TN93 clustering threshold
+    default: 0.01
+    minimum: 0
+  tn93_max_seqs:
+    type: integer
+    description: Maximum sequences retained per TN93 cluster
+    default: 20
+    minimum: 1
+  # GARD MPI settings
+  gard_processors:
+    type: integer
+    description: Number of MPI processors used for GARD
+    default: 4
+    minimum: 1
+  # MACSE Java memory tuning
+  macse_heap_fraction:
+    type: number
+    description: Fraction of requested memory used for MACSE heap sizing
+    default: 0.875
+    minimum: 0
+    maximum: 1
+  macse_heap_reserve_mb:
+    type: integer
+    description: Memory in MB reserved when sizing the MACSE heap
+    default: 1024
+    minimum: 1
+  macse_min_heap_mb:
+    type: integer
+    description: Minimum MACSE heap size in MB
+    default: 2048
+    minimum: 1
+  macse_xms_mb:
+    type: integer
+    description: Initial MACSE heap size in MB
+    default: 512
+    minimum: 1
+  macse_mem_mb:
+    type: integer
+    description: Optional explicit MACSE memory request in MB
+    minimum: 1
+  macse_heap_mb:
+    type: integer
+    description: Optional explicit MACSE heap size in MB
+    minimum: 1
+
+  log_dir:
+    type: string
+    description: Legacy compatibility log directory key
+    default: logs
+  multitestcorr:
+    type: string
+    description: Legacy compatibility multiple-test correction key
+    default: fdr
+
+required:
+  - shared_sequence_mode
+  - samples_csv
+
+if: 
+  properties:
+    shared_sequence_mode:
+      const: true
+then:
+  required: 
+    - "sequences_csv"
+else:
+  not:
+    required:
+      - "sequences_csv"
+
+additionalProperties: false

--- a/workflow/schemas/per_sample_samples.schema.yaml
+++ b/workflow/schemas/per_sample_samples.schema.yaml
@@ -1,0 +1,20 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+description: entry of per-sample mode samples sheet
+properties:
+  sample:
+    type: string
+    description: sample name/identifier
+    uniqueItems: true
+  codon_fasta:
+    type: string
+    description: path to FASTA file with nucleotide sequences for sample
+  sequence_labels_csv:
+    type: string
+    description: path to CSV with labels for sequences in the codon_fasta
+
+required:
+  - sample
+  - codon_fasta
+
+additionalProperties: false

--- a/workflow/schemas/per_sequence_samples.schema.yaml
+++ b/workflow/schemas/per_sequence_samples.schema.yaml
@@ -1,0 +1,20 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+description: entry of shared-sequence mode samples sheet
+properties:
+  sample:
+    type: string
+    description: sample name/identifier
+    uniqueItems: true
+  sequence:
+    type: string
+    description: name of sequence (must match sequence in sequences_csv)
+  sequence_labels_csv:
+    type: string
+    description: path to CSV with labels for sequences in the codon_fasta
+
+required:
+  - sample
+  - sequence
+
+additionalProperties: false

--- a/workflow/schemas/sequence_labels.schema.yaml
+++ b/workflow/schemas/sequence_labels.schema.yaml
@@ -1,0 +1,38 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+description: entry of a sequence_labels sheet
+# Three possible cases:
+oneOf:
+  - required: [sample]
+    minProperties: 3
+    maxProperties: 3
+  - not:
+      required: [sample]
+    minProperties: 2
+    maxProperties: 2
+  - patternProperties:
+      "label|group|set|class|foreground|branchset":
+        type: string
+      "fasta_sequence_header|sequence_header|seq_header|id|name|taxon|tip|sequence":
+        type: string
+    allOf:
+    - comment: "Enforce that at least one property matches the ^foo_ pattern"
+      propertyNames:
+        anyOf:
+          - pattern: "^label|group|set|class|foreground|branchset$"
+          - not:
+              pattern: "^label|group|set|class|foreground|branchset$"
+      not:
+        propertyNames:
+          not:
+            pattern: "^label|group|set|class|foreground|branchset$"
+    - comment: "Enforce that at least one property matches the ^bar_ pattern"
+      propertyNames:
+        anyOf:
+          - pattern: "^fasta_sequence_header|sequence_header|seq_header|id|name|taxon|tip|sequence$"
+          - not:
+              pattern: "^fasta_sequence_header|sequence_header|seq_header|id|name|taxon|tip|sequence$"
+      not:
+        propertyNames:
+          not:
+            pattern: "^fasta_sequence_header|sequence_header|seq_header|id|name|taxon|tip|sequence$"

--- a/workflow/schemas/sequences.schema.yaml
+++ b/workflow/schemas/sequences.schema.yaml
@@ -1,0 +1,17 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+description: entry of shared-sequence mode sequences sheet
+properties:
+  sequence:
+    type: string
+    description: sequence name/identifier (must be unique)
+    uniqueItems: true
+  codon_fasta:
+    type: string
+    description: path to FASTA file with nucleotide sequences for sample
+
+required:
+  - sequence
+  - codon_fasta
+
+additionalProperties: false


### PR DESCRIPTION
Snakemake has a [validate](https://snakemake.readthedocs.io/en/v7.32.0/snakefiles/configuration.html#validation) utility function that can be used to validate pandas dataframes and yaml files using a json schema. Using schemas for AOC input files would greatly reduce the amount of checking that needs to be done within the Snakefile.

This pull request adds json schemas (in yaml format) for the config file, the samples and sequences file, and the labels file.

It also adds validate commands to the the beginning of the snakefile for samples_csv and sequences_csv and to the build_header_map_and_test_list rule for lables.csv.

Finally, it adds a mandatory `shared_sequence_mode` file to the config file to explicitly switch that mode on and off, and only accepts sequences.csv if `shared_sequence_mode` is set to true

So now basically Snakemake automatically checks that the values in the config file makes sense and that samples_csv and sometimes sequences_csv have the right columns and fails immediately if somethings wrong.

By the by, I'm pretty sure that I got the schema for sequence labels to the point that it checks for the same things that build_header_map_and_test_list checks for. The one exception is that it will accept a labels file that looks like:

```csv
sample,not_any_of_the_label_options,not_any_of_the_header_options
```

Similiar to how the script will accept a file with only two columns.

Let's see: this does run on the test script (as long as sequences_csv is commented out in config) and I did add notes about shared_sequence_mode to the README, so hopefully this looks good.